### PR TITLE
Document permissions and add example workflow / integration job

### DIFF
--- a/.github/commenter.yml
+++ b/.github/commenter.yml
@@ -1,0 +1,21 @@
+Backend:
+  where:
+    path:
+      matches: "backend/**/*"
+  body: |
+    :wave: You've changed Backend code, please:
+
+    - [ ] Do this
+    - [ ] And this
+    - [ ] And that
+
+Frontend:
+  where:
+    path:
+      matches: "frontend/**/*"
+  body: |
+    :wave: You've changed Frontend code, please:
+
+    - [ ] Do this
+    - [ ] And this
+    - [ ] And that

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,14 @@ jobs:
       - run: npm install
       - run: npm run build
       - run: npm test
+  
+  integration:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ./
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -1,0 +1,13 @@
+name: Example
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/commenter@v1
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -54,6 +54,24 @@ jobs:
 
 See [`action.yml`](./action.yml).
 
+## Permissions
+
+Running this action requires the following permissions:
+
+```yaml
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+```
+
+These are required to be explicitly set for repositories with [restricted
+default access][perms] for workflows or to allow a workflow run triggered by
+Dependabot pull requests, which are run as if they are from a forked
+repository and use a read-only `GITHUB_TOKEN`.
+
+[perms]: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+
 ## Additional Options
 
 You can also match based on specific file changes by supplying the

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ Running this action requires the following permissions:
 
 ```yaml
 permissions:
-  id-token: write
   contents: read
   pull-requests: write
 ```


### PR DESCRIPTION
Documents minimum permissions required for the action to run in repos with restricted default permissions for workflows or for PRs created by Dependabot. These were established by a bit of trial and error in https://github.com/freckle/megarepo/pull/30954 (private repository).