### PR TITLE
Add `where.diff` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ and use a read-only `GITHUB_TOKEN`.
 ## Additional Options
 
 You can also match based on specific file changes by supplying the
-`additions_or_deletions` `where`-clause configuration key.
+`diff` `where`-clause configuration key.
 
 For example, if you wanted to comment on any changes that contain the word
 "unsafe" you could supply a YAML configuration like the following
@@ -102,13 +102,16 @@ UnsafeMentionedInCode:
   where:
     path:
       matches: "backend/**/*.hs"
-    additions_or_deletions:
-      contain:
+    diff:
+      contains:
         - unsafe
   body: |
     :wave: Hi, I see a mention of "unsafe" in Haskell code. If you removed it,
     good going! If you added it, please consider finding a safer alternative!
 ```
+
+`diff.adds` and `diff.removes` are also supported, to match on specifically
+additions or removals of certain text.
 
 Use `where.author.any` to only comment on PRs that authored by specific users,
 and `where.labels.any` to only comment when specific labels are present. Keep

--- a/__tests__/fixtures/patch_contains.yml
+++ b/__tests__/fixtures/patch_contains.yml
@@ -2,8 +2,8 @@ patch-matches-within-file:
   where:
     path:
       matches: "*.sql"
-    additions_or_deletions:
-      contain:
+    diff:
+      contains:
         - TRUNCATE
   body: |
     Looks like you changed a TRUNCATE line...

--- a/src/where.test.ts
+++ b/src/where.test.ts
@@ -12,7 +12,7 @@ const changes: Changes = {
   changedFiles: [
     {
       filename: "foo.ts",
-      patch: "+ adding unsafe",
+      patch: "+ adding unsafe\n- removing safe\n",
     },
     {
       filename: "bar.ts",
@@ -20,7 +20,7 @@ const changes: Changes = {
     },
     {
       filename: "baz/quiz.ts",
-      patch: "",
+      patch: "- removing important\n+ adding unimportant\n",
     },
   ],
   author: "pbrisbin",
@@ -49,6 +49,30 @@ const matched: TestCase[] = [
     clause: {
       path: { matches: "baz/*.ts" },
       labels: { any: ["v2"] },
+    },
+  },
+  {
+    attr: "diff.contains",
+    changes,
+    clause: {
+      path: { matches: "foo.ts" },
+      diff: { contains: ["unsafe"] },
+    },
+  },
+  {
+    attr: "diff.adds",
+    changes,
+    clause: {
+      path: { matches: "foo.ts" },
+      diff: { adds: ["unsafe"] },
+    },
+  },
+  {
+    attr: "diff.removes",
+    changes,
+    clause: {
+      path: { matches: "baz/quiz.ts" },
+      diff: { removes: ["important"] },
     },
   },
   {
@@ -83,6 +107,30 @@ const missed: TestCase[] = [
     clause: {
       path: { matches: "baz/*.ts" },
       labels: { any: ["bugfix"] },
+    },
+  },
+  {
+    attr: "diff.contains",
+    changes,
+    clause: {
+      path: { matches: "foo.ts" },
+      diff: { contains: ["something else"] },
+    },
+  },
+  {
+    attr: "diff.adds",
+    changes,
+    clause: {
+      path: { matches: "foo.ts" },
+      diff: { adds: ["important"] },
+    },
+  },
+  {
+    attr: "diff.removes",
+    changes,
+    clause: {
+      path: { matches: "baz/quiz.ts" },
+      diff: { removes: ["something"] },
     },
   },
   {

--- a/src/where.test.ts
+++ b/src/where.test.ts
@@ -3,8 +3,9 @@ import { ConfigurationWhereClause } from "./where";
 import * as where from "./where";
 
 type TestCase = {
-  attr: string;
   changes: Changes;
+  expected: boolean;
+  name: string;
   clause: ConfigurationWhereClause;
 };
 
@@ -27,136 +28,31 @@ const changes: Changes = {
   labels: ["feature", "v2"],
 };
 
-const matched: TestCase[] = [
-  {
-    attr: "path",
-    changes,
-    clause: {
-      path: { matches: "baz/*.ts" },
-    },
-  },
-  {
-    attr: "author",
-    changes,
-    clause: {
-      path: { matches: "baz/*.ts" },
-      author: { any: ["dependabot", "pbrisbin"] },
-    },
-  },
-  {
-    attr: "label",
-    changes,
-    clause: {
-      path: { matches: "baz/*.ts" },
-      labels: { any: ["v2"] },
-    },
-  },
-  {
-    attr: "diff.contains",
-    changes,
-    clause: {
-      path: { matches: "foo.ts" },
-      diff: { contains: ["unsafe"] },
-    },
-  },
-  {
-    attr: "diff.adds",
-    changes,
-    clause: {
-      path: { matches: "foo.ts" },
-      diff: { adds: ["unsafe"] },
-    },
-  },
-  {
-    attr: "diff.removes",
-    changes,
-    clause: {
-      path: { matches: "baz/quiz.ts" },
-      diff: { removes: ["important"] },
-    },
-  },
-  {
-    attr: "additions_or_deletions",
-    changes,
-    clause: {
-      path: { matches: "foo.ts" },
-      additions_or_deletions: { contain: ["unsafe"] },
-    },
-  },
-];
-
-const missed: TestCase[] = [
-  {
-    attr: "path",
-    changes,
-    clause: {
-      path: { matches: "other.ts" },
-    },
-  },
-  {
-    attr: "author",
-    changes,
-    clause: {
-      path: { matches: "baz/*.ts" },
-      author: { any: ["dependabot"] },
-    },
-  },
-  {
-    attr: "label",
-    changes,
-    clause: {
-      path: { matches: "baz/*.ts" },
-      labels: { any: ["bugfix"] },
-    },
-  },
-  {
-    attr: "diff.contains",
-    changes,
-    clause: {
-      path: { matches: "foo.ts" },
-      diff: { contains: ["something else"] },
-    },
-  },
-  {
-    attr: "diff.adds",
-    changes,
-    clause: {
-      path: { matches: "foo.ts" },
-      diff: { adds: ["important"] },
-    },
-  },
-  {
-    attr: "diff.removes",
-    changes,
-    clause: {
-      path: { matches: "baz/quiz.ts" },
-      diff: { removes: ["something"] },
-    },
-  },
-  {
-    attr: "additions_or_deletions",
-    changes,
-    clause: {
-      path: { matches: "foo.ts" },
-      additions_or_deletions: { contain: ["something else"] },
-    },
-  },
-  {
-    attr: "file's additions_or_deletions",
-    changes,
-    clause: {
-      path: { matches: "baz/*.ts" },
-      additions_or_deletions: { contain: ["unsafe"] },
-    },
-  },
+// Manually align this, so it can be more easily scanned
+// prettier-ignore
+const cases: TestCase[] = [
+  { changes, expected: true,  name: "path",                          clause: { path: { matches: "baz/*.ts"    }}},
+  { changes, expected: true,  name: "author",                        clause: { path: { matches: "baz/*.ts"    }, author: { any: ["dependabot", "pbrisbin"] }}},
+  { changes, expected: true,  name: "label",                         clause: { path: { matches: "baz/*.ts"    }, labels: { any: ["v2"] }}},
+  { changes, expected: true,  name: "diff.contains",                 clause: { path: { matches: "foo.ts"      }, diff: { contains: ["unsafe"] }}},
+  { changes, expected: true,  name: "diff.adds",                     clause: { path: { matches: "foo.ts"      }, diff: { adds: ["unsafe"] }}},
+  { changes, expected: true,  name: "diff.removes",                  clause: { path: { matches: "baz/quiz.ts" }, diff: { removes: ["important"] }}},
+  { changes, expected: true,  name: "additions_or_deletions",        clause: { path: { matches: "foo.ts"      }, additions_or_deletions: { contain: ["unsafe"] }}},
+  { changes, expected: false, name: "path",                          clause: { path: { matches: "other.ts"    }}},
+  { changes, expected: false, name: "author",                        clause: { path: { matches: "baz/*.ts"    }, author: { any: ["dependabot"] }}},
+  { changes, expected: false, name: "label",                         clause: { path: { matches: "baz/*.ts"    }, labels: { any: ["bugfix"] }}},
+  { changes, expected: false, name: "diff.contains",                 clause: { path: { matches: "foo.ts"      }, diff: { contains: ["something else"] }}},
+  { changes, expected: false, name: "diff.adds",                     clause: { path: { matches: "foo.ts"      }, diff: { adds: ["important"] }}},
+  { changes, expected: false, name: "diff.removes",                  clause: { path: { matches: "baz/quiz.ts" }, diff: { removes: ["something"] }}},
+  { changes, expected: false, name: "additions_or_deletions",        clause: { path: { matches: "foo.ts"      }, additions_or_deletions: { contain: ["something else"] }}},
+  { changes, expected: false, name: "file's additions_or_deletions", clause: { path: { matches: "baz/*.ts"    }, additions_or_deletions: { contain: ["unsafe"] }}},
 ];
 
 describe("matches", () => {
-  it.each(matched)("matches by $attr", ({ changes, clause }) => {
-    expect(where.matches(changes, clause)).toBe(true);
-  });
-
-  it.each(missed)("does not match a different $attr", ({ changes, clause }) => {
-    expect(where.matches(changes, clause)).toBe(false);
-  });
+  it.each(cases)(
+    "where.matches($name): $expected",
+    ({ changes, clause, expected }) => {
+      expect(where.matches(changes, clause)).toBe(expected);
+    },
+  );
 });

--- a/src/where.ts
+++ b/src/where.ts
@@ -6,14 +6,17 @@ export type ConfigurationWhereClause = {
   path: {
     matches: string;
   };
-  additions_or_deletions?: {
-    contain: string[];
-  };
+  diff?: Diff;
   author?: {
     any: string[];
   };
   labels?: {
     any: string[];
+  };
+
+  // deprecated, still supported
+  additions_or_deletions?: {
+    contain: string[];
   };
 };
 
@@ -24,12 +27,17 @@ export function matches(
   const { changedFiles, author, labels } = changes;
   const matcher = new Minimatch(where.path.matches);
 
-  const hasFileMatch = changedFiles.some(
-    ({ filename, patch }) =>
-      matcher.match(filename) &&
-      (!where.additions_or_deletions ||
-        patchContains(patch, where.additions_or_deletions.contain)),
-  );
+  // Treat deprecated additions_or_deletions.contain as diff.contains, but note
+  // that if additions_or_deletions is present, diff is ignored.
+  const whereDiff = where.additions_or_deletions
+    ? { contains: where.additions_or_deletions.contain }
+    : where.diff;
+
+  const hasFileMatch = changedFiles.some(({ filename, patch: rawPatch }) => {
+    const patch = toPatch(rawPatch);
+    const matchedDiff = whereDiff ? matchesDiff(patch, whereDiff) : true;
+    return matcher.match(filename) && matchedDiff;
+  });
 
   const hasAuthorMatch =
     !where.author ||
@@ -41,5 +49,40 @@ export function matches(
   return hasFileMatch && hasAuthorMatch && hasLabelMatch;
 }
 
-const patchContains = (patch: string, needles: string[]) =>
-  needles.some((needle) => patch.includes(needle));
+type Patch = {
+  added: string[];
+  removed: string[];
+  lines: string[];
+};
+
+function toPatch(raw: string): Patch {
+  const lines = raw.split("\n");
+  const added = lines.filter((x) => x.match(/^\+ /));
+  const removed = lines.filter((x) => x.match(/^- /));
+  return { added, removed, lines };
+}
+
+type Diff = {
+  contains?: string[];
+  adds?: string[];
+  removes?: string[];
+};
+
+function matchesDiff(
+  { added, removed, lines }: Patch,
+  { contains, adds, removes }: Diff,
+): boolean {
+  const bs = [
+    contains && lines.length > 0
+      ? contains.some((x) => lines.some((l) => l.includes(x)))
+      : true,
+    adds && added.length > 0
+      ? adds.some((x) => added.some((l) => l.includes(x)))
+      : true,
+    removes && removed.length > 0
+      ? removes.some((x) => removed.some((l) => l.includes(x)))
+      : true,
+  ];
+
+  return bs.every((x) => x);
+}


### PR DESCRIPTION
Configuration changes:

- `diff.contains` replaces `additions_or_removals.contain` (latter still supported)
- `diff.adds` and `diff.removes` are then added

With the additional unit tests on the `where` module, I think a lot of the `main.test.ts` tests are superfluous as they're testing thing matching logic indirectly.

### [Add where.diff support](https://github.com/freckle/commenter-action/pull/545/commits/a0b62bbfabe72e12a1017c708e6f2ec4304c04f2) :point_left: important commit
[a0b62bb](https://github.com/freckle/commenter-action/pull/545/commits/a0b62bbfabe72e12a1017c708e6f2ec4304c04f2)

Closes https://github.com/freckle/commenter-action/issues/112.

### [Update tests and README to use diff](https://github.com/freckle/commenter-action/pull/545/commits/b10d8dcb9fa953e2c393bf89de42571a96d017ab)
[b10d8dc](https://github.com/freckle/commenter-action/pull/545/commits/b10d8dcb9fa953e2c393bf89de42571a96d017ab)

### [Re-format where test cases for readability](https://github.com/freckle/commenter-action/pull/545/commits/f54e37922e82021607376accdad8a894b88c542e) :point_left: behavior neutral, but messy
[f54e379](https://github.com/freckle/commenter-action/pull/545/commits/f54e37922e82021607376accdad8a894b88c542e)

- Combine separate matched/mixed lists with an `expected` key
- Disable prettier and align things manually